### PR TITLE
Fix MCP SSE client error handling

### DIFF
--- a/homeassistant/components/mcp/coordinator.py
+++ b/homeassistant/components/mcp/coordinator.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 import datetime
 import logging
 
+from anyio import BrokenResourceError
 import httpx
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
@@ -53,6 +54,9 @@ async def mcp_client(
             yield session
     except ExceptionGroup as err:
         _LOGGER.debug("Error creating MCP client: %s", err)
+        for exc in err.exceptions:
+            if not isinstance(exc, BrokenResourceError):
+                raise exc from err
         raise err.exceptions[0] from err
 
 


### PR DESCRIPTION
## Summary
- improve error handling for MCP SSE client

## Testing
- `pre-commit run --files homeassistant/components/mcp/coordinator.py` *(fails: mypy and pylint not installed)*
- `pytest tests/components/mcp -q` *(fails: `sqlalchemy` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68404e23686c8327ad2bd3e529908e57