### PR TITLE
Restore OAuth2 fallback in MCP

### DIFF
--- a/homeassistant/components/mcp/config_flow.py
+++ b/homeassistant/components/mcp/config_flow.py
@@ -184,6 +184,7 @@ async def validate_input(
             error.response.status_code,
         )
         if error.response.status_code == 401:
+            # Trigger OAuth2 discovery when API key authentication fails
             raise InvalidAuth from error
         raise CannotConnect from error
     except httpx.HTTPError as error:
@@ -332,6 +333,7 @@ class ModelContextProtocolConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
         except CannotConnect:
             return self.async_abort(reason="cannot_connect")
         except InvalidAuth:
+            # OAuth credentials were rejected
             return self.async_abort(reason="invalid_auth")
         except MissingCapabilities:
             return self.async_abort(reason="missing_capabilities")

--- a/homeassistant/components/mcp/config_flow.py
+++ b/homeassistant/components/mcp/config_flow.py
@@ -331,6 +331,8 @@ class ModelContextProtocolConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):
             return self.async_abort(reason="timeout_connect")
         except CannotConnect:
             return self.async_abort(reason="cannot_connect")
+        except InvalidAuth:
+            return self.async_abort(reason="invalid_auth")
         except MissingCapabilities:
             return self.async_abort(reason="missing_capabilities")
         except Exception:

--- a/homeassistant/components/mcp/coordinator.py
+++ b/homeassistant/components/mcp/coordinator.py
@@ -212,9 +212,9 @@ class ModelContextProtocolCoordinator(DataUpdateCoordinator[list[llm.Tool]]):
             raise UpdateFailed(f"Timeout when listing tools: {error}") from error
         except httpx.HTTPStatusError as error:
             _LOGGER.debug("Error communicating with API: %s", error)
-            if error.response.status_code == 401 and self.token_manager is not None:
+            if error.response.status_code == 401:
                 raise ConfigEntryAuthFailed(
-                    "The MCP server requires authentication"
+                    "Authentication with the MCP server failed"
                 ) from error
             raise UpdateFailed(f"Error communicating with API: {error}") from error
         except httpx.HTTPError as err:

--- a/tests/components/mcp/test_init.py
+++ b/tests/components/mcp/test_init.py
@@ -81,7 +81,6 @@ async def test_init(
     [
         (httpx.TimeoutException("Some timeout")),
         (httpx.HTTPStatusError("", request=None, response=httpx.Response(500))),
-        (httpx.HTTPStatusError("", request=None, response=httpx.Response(401))),
         (httpx.HTTPError("Some HTTP error")),
     ],
 )
@@ -111,6 +110,25 @@ async def test_mcp_server_authentication_failure(
 
     await hass.config_entries.async_setup(config_entry_with_auth.entry_id)
     assert config_entry_with_auth.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"
+
+
+async def test_mcp_server_authentication_failure_no_auth(
+    hass: HomeAssistant,
+    credential: None,
+    config_entry: MockConfigEntry,
+    mock_mcp_client: Mock,
+) -> None:
+    """Test the integration starts OAuth reauth when API key auth fails."""
+    mock_mcp_client.side_effect = httpx.HTTPStatusError(
+        "Authentication required", request=None, response=httpx.Response(401)
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1


### PR DESCRIPTION
## Summary
- raise `ConfigEntryAuthFailed` on HTTP 401 in the MCP coordinator
- test OAuth reauth when API key auth fails

## Testing
- `pre-commit run --files homeassistant/components/mcp/coordinator.py tests/components/mcp/test_init.py`
- `pytest tests/components/mcp/test_init.py::test_mcp_server_authentication_failure_no_auth -q`

------
https://chatgpt.com/codex/tasks/task_e_68474ddc0bfc8327bf2d984b8586574c